### PR TITLE
Version bump pnet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT"
 repository = "https://github.com/LivingInSyn/udp_crafter"
 
 [dependencies]
-pnet = "0.21.0"
+pnet = "0.28.0"


### PR DESCRIPTION
Pnet 0.21.0 can't compile anymore, so we need a version bump to be able to use this Crate.